### PR TITLE
added guard to assert zero clipboard client exists

### DIFF
--- a/addon/components/zero-clipboard.js
+++ b/addon/components/zero-clipboard.js
@@ -4,9 +4,10 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   attributeBindings: ['title', 'data-clipboard-text', 'data-clipboard-target'],
   title: 'Copy to clipboard',
-  
+
   didInsertElement: function() {
     var client = new ZeroClipboard(this.get('element'));
+    if (!client) { return; }
 
     //bind aftercopy to an ember event
     client.on("aftercopy", Ember.run.bind(this, function(event) {


### PR DESCRIPTION
Added guard to assert that the client exists. This was blowing up in PhantomJS in Travis otherwise

<img width="1267" alt="screen shot 2015-07-11 at 11 39 24 am" src="https://cloud.githubusercontent.com/assets/61075/8634349/6f44a39a-27c3-11e5-84f4-05baf96ce65b.png">
