### PR TITLE
Allow closure actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ export default ZeroClipboard.extend({
 });
 ```
 
+You can also pass a closure action, without subclassing the component.
+
+```hbs
+{{zero-clipboard afterCopy=(action "alertAfterCopy")}}
+
+```
+
 Pass a block if you want to customize the html:
 
 ``` hbs

--- a/addon/components/zero-clipboard.js
+++ b/addon/components/zero-clipboard.js
@@ -14,11 +14,15 @@ export default Ember.Component.extend({
     this.get('zeroClipboardEvents').forEach(function(action){
       client.on(action, Ember.run.bind(this, function(event) {
         try {
-      	  this.send(action, event);
-      	}
-      	catch(error) {
-      	  Ember.Logger.debug(error.message);
-      	}
+          if(this.attrs[action]) {
+            this.attrs[action](event);
+          } else {
+            this.send(action, event);
+          }
+        }
+        catch(error) {
+          Ember.Logger.debug(error.message);
+        }
       }));
     }, self);
   },


### PR DESCRIPTION
By allowing closure actions to be submitted, users can respond to events without
needing to subclass the original component.