### PR TITLE
Updated to support Ember 2.0

### DIFF
--- a/app/templates/components/zero-clipboard.hbs
+++ b/app/templates/components/zero-clipboard.hbs
@@ -1,4 +1,4 @@
-{{#if template}}
+{{#if hasBlock}}
   {{yield}}
 {{else}}
   <button class="{{innerClass}}">{{label}}</button>


### PR DESCRIPTION
`template` has been deprecated in Ember 1.13 and removed from Ember 2.0. The new form for a block is to use the `hasBlock` keyword. More information here http://emberjs.com/blog/2015/06/12/ember-1-13-0-released.html#toc_component-block-info